### PR TITLE
fix(lorax): typo in command name

### DIFF
--- a/src/modules/lorax/commands/users.rs
+++ b/src/modules/lorax/commands/users.rs
@@ -399,7 +399,7 @@ pub async fn vote(ctx: Context<'_>) -> Result<(), Error> {
         }
     }
 
-    ctx.say("⌛ Time's up! Feel free to `/vote` again anytime.")
+    ctx.say("⌛ Time's up! Feel free to `/lorax vote` again anytime.")
         .await?;
     Ok(())
 }


### PR DESCRIPTION
`/vote` is being handled by a different bot, not "prometheus" (this bot). I replaced the text with `/lorax vote`, which is the correct one.